### PR TITLE
Call predicate exactly once on items

### DIFF
--- a/contextfun/main.py
+++ b/contextfun/main.py
@@ -60,11 +60,12 @@ def contextual_filter(iterable, predicate, before=0, after=0, quantifier=all):
     """
     size = int(before) + int(after) + 1
     fake = object()
+    iterable = ((x, predicate(x)) for x in iterable)
     for i in frameiter(iterable, size, fake=fake, before=before, after=after):
         context = i[:before] + i[before+1:]
-        context = (predicate(x) for x in context if x != fake)
+        context = (x[1] for x in context if x != fake)
         if quantifier(context):
-            yield i[before]
+            yield i[before][0]
 
 
 def contextual_map(iterable, mapping, predicate, before=0, after=0, quantifier=all):
@@ -91,10 +92,11 @@ def contextual_map(iterable, mapping, predicate, before=0, after=0, quantifier=a
     """
     size = before + after + 1
     fake = object()
+    iterable = ((x, predicate(x)) for x in iterable)
     for i in frameiter(iterable, size, fake=fake, before=before, after=after):
         context = i[:before] + i[before+1:]
-        context = (predicate(x) for x in context if x != fake)
+        context = (x[1] for x in context if x != fake)
         if quantifier(context):
-            yield mapping(i[before])
+            yield mapping(i[before][0])
         else:
-            yield i[before]
+            yield i[before][0]

--- a/test/test_performance.py
+++ b/test/test_performance.py
@@ -1,0 +1,27 @@
+from contextfun import contextual_filter, contextual_map
+
+
+class ExecutionCounterPredicate(object):
+    def __init__(self):
+        self.n = {}
+
+    def __call__(self, x):
+        self.n[x] = self.n.get(x, 0) + 1
+        return True
+
+
+def _predicate_called_once_per_item(f, **kwargs):
+    span = 5
+    iterable = [object() for i in range(span+1)]
+    predicate = ExecutionCounterPredicate()
+    list(f(iterable=iterable, predicate=predicate, before=span, **kwargs))
+    assert predicate.n[iterable[0]] != span
+    assert predicate.n[iterable[0]] == 1
+
+
+def test_filter_calls_predicate_once_per_item():
+    _predicate_called_once_per_item(contextual_filter)
+
+
+def test_map_calls_predicate_once_per_item():
+    _predicate_called_once_per_item(contextual_map, mapping=id)


### PR DESCRIPTION
In your code the `predicate` is called every time the context of an item is running through the `quantifier`. I demonstrate this in the first commit by a test that will fail on the original code for this reason.
In my interpretation, the individual calls to the `predicate` are independent of each other, and it should not be called more than once for any item, so it should be memoized.
In the second commit I fix the implementation in `main.py` accordingly. I tried to choose the least intrusive solution, however it may not be the most beautiful one.